### PR TITLE
:tada: Snapshots now stored on tabs

### DIFF
--- a/client/src/Containers/Monitoring/RoomPreview.js
+++ b/client/src/Containers/Monitoring/RoomPreview.js
@@ -43,7 +43,9 @@ function RoomPreview({ roomId }) {
   // getTimestamp(key) returns the timestamp (Unix epoch time) at that key
   const { getKeys, getSnapshot, getTimestamp } = useSnapshots(
     () => {},
-    isSuccess ? data.snapshot : {}
+    isSuccess
+      ? data.tabs.reduce((acc, tab) => ({ ...acc, ...tab.snapshot }), {})
+      : {}
   );
 
   // Update the thumbnail either when the selection changes or when new data come in (potentially a new snapshot)

--- a/client/src/Containers/Monitoring/SelectionTable.js
+++ b/client/src/Containers/Monitoring/SelectionTable.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { useSortableData } from '../../utils';
-import './selectionTable.css';
+import classes from './selectionTable.css';
 
 /**
  * Implements a table that allows for selecting / deselecting of each row and for sorting based on columns.  Right now, the implementation
@@ -64,7 +64,7 @@ export default function SelectionTable(props) {
             <button
               type="button"
               onClick={() => requestSort('name')}
-              className={getClassNamesFor('name')}
+              className={classes[getClassNamesFor('name')]}
             >
               Room Name
             </button>
@@ -73,7 +73,7 @@ export default function SelectionTable(props) {
             <button
               type="button"
               onClick={() => requestSort('currentMembers')}
-              className={getClassNamesFor('currentMembers')}
+              className={classes[getClassNamesFor('currentMembers')]}
             >
               Currently In Room
             </button>
@@ -82,7 +82,7 @@ export default function SelectionTable(props) {
             <button
               type="button"
               onClick={() => requestSort('updatedAt')}
-              className={getClassNamesFor('updatedAt')}
+              className={classes[getClassNamesFor('updatedAt')]}
             >
               Last Updated
             </button>
@@ -91,7 +91,7 @@ export default function SelectionTable(props) {
             <button
               type="button"
               onClick={() => requestSort('createdAt')}
-              className={getClassNamesFor('createdAt')}
+              className={classes[getClassNamesFor('createdAt')]}
             >
               Created
             </button>

--- a/client/src/Containers/Monitoring/selectionTable.css
+++ b/client/src/Containers/Monitoring/selectionTable.css
@@ -26,17 +26,17 @@ thead button {
 
 /* not sure why below doesn't work */
 
-/* thead button.ascending::after {
-  content: '👇';
+.ascending::after {
+  content: '↑';
   display: inline-block;
   margin-left: 1em;
 }
 
-thead button.descending::after {
-  content: '☝️';
+.descending::after {
+  content: '↓';
   display: inline-block;
   margin-left: 1em;
-} */
+}
 
 tbody td {
   padding: 0.5em;

--- a/server/models/Tab.js
+++ b/server/models/Tab.js
@@ -37,6 +37,7 @@ const Tab = new mongoose.Schema(
     isTrashed: { type: Boolean, default: false },
     visitors: [{ type: ObjectId, ref: 'User' }], // unique list of users who have viewed this tab
     visitorsSinceInstructionsUpdated: [{ type: ObjectId, ref: 'User' }], // used to determine if should show instructions modal; reset every time instructions have been updated
+    snapshot: {},
   },
   { timestamps: true }
 );


### PR DESCRIPTION
Snapshots now stored on tabs
- Updated useSnapshots to take a baseObject (to use if nothing was supplied when the hook was called)
- Workspace now uses the API to write to the tabs collection
- MonitoringView and RoomPreview updated (slightly) to accumulate all tabs' snapshots
- BONUS: updated SelectionTable so that direction of sort is indicated

Note that this change involves changing the schema for Tabs (adding a snapshot field). Thus, the VMT server needs to be rebuilt and deployed as well as the VMT client.