### PR TITLE
CurrentMembers as functional component

### DIFF
--- a/client/src/Components/CurrentMembers/CurrentMembers.js
+++ b/client/src/Components/CurrentMembers/CurrentMembers.js
@@ -1,83 +1,71 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classes from './currentMembers.css';
 import Avatar from '../UI/Avatar/Avatar';
 
-class CurrentMembers extends Component {
-  constructor(props) {
-    super(props);
+function CurrentMembers({
+  currentMembers,
+  members,
+  activeMember,
+  expanded,
+  toggleExpansion,
+}) {
+  const [presentMembers, setPresentMembers] = React.useState([]);
 
-    this.state = { presentMembers: this.getPresentMembers() };
-  }
+  React.useEffect(() => {
+    // filter out any malformed members. Of course, this has the effect of potentially not showing someone who is there.
+    const currmembers = currentMembers.filter((m) => m && m._id);
+    // Creatings new array of members in the room so that we have all of the member metadata (inc color)
+    // note that the members array and the currentMembers array have objects of different structure.
+    const result = currmembers.map((member) =>
+      members.find((m) => m.user._id === member._id)
+    );
+    setPresentMembers(result);
+  }, [currentMembers]);
 
-  componentDidUpdate = (prevProps) => {
-    const { currentMembers } = this.props;
-    if (prevProps.currentMembers === currentMembers) return;
-    this.setState({ presentMembers: this.getPresentMembers() });
-  };
-
-  toggleExpansion = () => {
-    const { toggleExpansion } = this.props;
+  const _toggle = () => {
     if (toggleExpansion) {
       toggleExpansion('members');
     }
   };
 
-  getPresentMembers = () => {
-    const { currentMembers, members } = this.props;
-
-    // filter out any malformed members. Of course, this has the effect of potentially not showing someone who is there.
-    const currmembers = currentMembers.filter((m) => m && m._id);
-    // Creatings new array of members in the room so that we have all of the member metadata (inc color)
-    // note that the members array and the currentMembers array have objects of different structure.
-    const presentMembers = currmembers.map((member) =>
-      members.find((m) => m.user._id === member._id)
-    );
-    return presentMembers;
-  };
-
-  render() {
-    const { activeMember, expanded } = this.props;
-    const { presentMembers } = this.state;
-
-    return (
-      <div className={classes.Container}>
-        <div
-          className={classes.Title}
-          onClick={this.toggleExpansion}
-          onKeyPress={this.toggleExpansion}
-          role="button"
-          tabIndex="-1"
-        >
-          Currently in this room
-          <div className={classes.Count}>{presentMembers.length}</div>
-        </div>
-        <div
-          className={expanded ? classes.Expanded : classes.Collapsed}
-          data-testid="current-members"
-        >
-          {presentMembers.map((presMember) => {
-            return (
-              <div
-                className={[
-                  classes.Avatar,
-                  activeMember && presMember.user._id === activeMember
-                    ? classes.Active
-                    : classes.Passive,
-                ].join(' ')}
-                key={presMember._id}
-              >
-                <Avatar
-                  username={presMember.user.username}
-                  color={presMember.color}
-                />
-              </div>
-            );
-          })}
-        </div>
+  return (
+    <div className={classes.Container}>
+      <div
+        className={classes.Title}
+        onClick={_toggle}
+        onKeyPress={_toggle}
+        role="button"
+        tabIndex="-1"
+      >
+        Currently in this room
+        <div className={classes.Count}>{presentMembers.length}</div>
       </div>
-    );
-  }
+      <div
+        className={expanded ? classes.Expanded : classes.Collapsed}
+        data-testid="current-members"
+      >
+        {presentMembers.map((presMember) => {
+          return (
+            <div
+              className={[
+                classes.Avatar,
+                activeMember && presMember.user._id === activeMember
+                  ? classes.Active
+                  : classes.Passive,
+              ].join(' ')}
+              key={presMember._id}
+            >
+              <Avatar
+                username={presMember.user.username}
+                color={presMember.color}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 CurrentMembers.propTypes = {


### PR DESCRIPTION
Same 'presentMembers' algorithm, but without the chance of an infinite loop. If this doesn't behave as we'd like, we can go back to the other algorithm for figuring out presentMembers.

However, we really should address some deeper bugs, such as:
- "members" containing repeats of people occassionally
- the need to filter malformed users
- the "current in room" number in the lobby is often not accurate when you exit a room.