### PR TITLE
Add tab/screen selection to Monitoring

### DIFF
--- a/client/src/Components/UI/ToggleGroup/ToggleGroup.js
+++ b/client/src/Components/UI/ToggleGroup/ToggleGroup.js
@@ -4,10 +4,8 @@ import PropTypes from 'prop-types';
 import classes from './toggleGroup.css';
 
 export default function ToggleGroup(props) {
-  const { buttons, initialSelection, onChange } = props;
-  const [selection, setSelection] = React.useState(
-    initialSelection || buttons[0]
-  );
+  const { buttons, onChange, value } = props;
+  const [selection, setSelection] = React.useState(value || buttons[0]);
   const groupName = Math.random().toString();
 
   const _onChange = (event) => {
@@ -39,10 +37,10 @@ export default function ToggleGroup(props) {
 
 ToggleGroup.propTypes = {
   buttons: PropTypes.arrayOf(PropTypes.string).isRequired,
-  initialSelection: PropTypes.string,
+  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 
 ToggleGroup.defaultProps = {
-  initialSelection: null,
+  value: null,
 };

--- a/client/src/Containers/Monitoring/MonitoringView.js
+++ b/client/src/Containers/Monitoring/MonitoringView.js
@@ -260,11 +260,13 @@ function MonitoringView({
           <Fragment>
             <ToggleGroup
               buttons={[constants.CHAT, constants.THUMBNAIL, constants.GRAPH]}
+              value={viewType}
               onChange={setViewType}
             />
             {viewType === constants.CHAT && (
               <ToggleGroup
                 buttons={[constants.DETAILED, constants.SIMPLE]}
+                value={chatType}
                 onChange={setChatType}
               />
             )}

--- a/client/src/Containers/Monitoring/MonitoringView.js
+++ b/client/src/Containers/Monitoring/MonitoringView.js
@@ -7,12 +7,12 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { NavItem, ToggleGroup } from 'Components';
+import { NavItem, ToggleGroup, SimpleChat } from 'Components';
+import { Chart } from 'Containers';
 import { updateMonitorSelections } from 'store/actions';
-import statsReducer, { initialState } from 'Containers/Stats/statsReducer';
-import Chart from 'Containers/Stats/Chart';
-import SimpleChat from 'Components/Chat/SimpleChat';
 import { usePopulatedRoom, useSnapshots } from 'utils';
+import statsReducer, { initialState } from 'Containers/Stats/statsReducer';
+import Thumbnails from './Thumbnails';
 import SelectionTable from './SelectionTable';
 import classes from './monitoringView.css';
 import DropdownMenuClasses from './dropdownmenu.css';
@@ -45,8 +45,6 @@ import DropdownMenuClasses from './dropdownmenu.css';
  *  - Store entire state (room selections, toggle choices, scrollTop for each tile, etc.) in Redux store and restore MonitorView state accordingly
  *  - Show notifications for rooms
  *  - indicate 'last update' on each tile as well as number currently in room (but how to do this so isn't overly busy)
- *  - UPDATE TO USE USESNAPSHOT HOOK. This encapsulates a lot of the thumbnail logic.  Similarly, need to use the
- *      usePopulatedRoom hook.
  */
 
 function MonitoringView({
@@ -108,7 +106,6 @@ function MonitoringView({
   const [viewType, setViewType] = React.useState(constants.CHAT);
   const [chatType, setChatType] = React.useState(constants.DETAILED);
   const savedState = React.useRef(selections);
-  const { getKeys, getTimestamp, getSnapshot } = useSnapshots();
 
   // Because "useQuery" is the equivalent of useState, do this
   // initialization of queryStates (an object containing the states
@@ -205,25 +202,6 @@ function MonitoringView({
     ];
   };
 
-  const _getMostRecentSnapshot = (roomId) => {
-    if (!queryStates[roomId].isSuccess) return null;
-    // all the snapshots
-    const snapshotData = queryStates[roomId].data.tabs.reduce(
-      (acc, tab) => ({ ...acc, ...tab.snapshot }),
-      {}
-    );
-
-    let maxSoFar = 0;
-    let result = null;
-    getKeys(snapshotData).forEach((key) => {
-      if (getTimestamp(key, snapshotData) > maxSoFar) {
-        maxSoFar = getTimestamp(key, snapshotData);
-        result = getSnapshot(key, snapshotData);
-      }
-    });
-    return result;
-  };
-
   // The isSuccess test is really not needed because we don't render unless it's true. However,
   // it just seems clearer to keep the test here as we are using queryStates[].data
   const _displayViewType = (id) => {
@@ -242,11 +220,12 @@ function MonitoringView({
           />
         );
       case constants.THUMBNAIL: {
-        const snapshot = _getMostRecentSnapshot(id);
-        return snapshot && snapshot !== '' ? (
-          <img alt={`Snapshot of room ${id}`} src={snapshot} />
-        ) : (
-          <span className={classes.NoSnapshot}>No snapshot currently</span>
+        return (
+          <Thumbnails
+            populatedRoom={
+              queryStates[id].isSuccess ? queryStates[id].data : {}
+            }
+          />
         );
       }
       default:

--- a/client/src/Containers/Monitoring/RoomPreview.js
+++ b/client/src/Containers/Monitoring/RoomPreview.js
@@ -2,12 +2,12 @@
 /* eslint-disable no-shadow */
 /* eslint-disable no-undef */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import Select from 'react-select';
-import { usePopulatedRoom, useSnapshots } from 'utils/utilityHooks';
+import { usePopulatedRoom } from 'utils/utilityHooks';
 import { SimpleChat } from 'Components';
 import classes from './monitoringView.css';
+import Thumbnails from './Thumbnails';
 
 /**
  * The RoomPreview provides two views into a rooms: thumbnail and chat. Users can
@@ -29,140 +29,21 @@ import classes from './monitoringView.css';
 
 function RoomPreview({ roomId }) {
   //   const [chatType, setChatType] = React.useState(constants.DETAILED);
-  const [tabSelection, setTabSelection] = React.useState();
-  const [screenSelection, setScreenSelection] = React.useState();
-  const [thumbnail, setThumbnail] = React.useState();
 
   const { isSuccess, data } = usePopulatedRoom(roomId, false, {
     refetchInterval: 10000, // check for new info every 10 seconds
   });
 
-  // Functions for accessing information in the snapshot object.
-  // getKeys() returns an array of all the keys being used for snapshots
-  // getSnapshot(key) returns the snapshot (dataURL) at that key
-  // getTimestamp(key) returns the timestamp (Unix epoch time) at that key
-  const { getKeys, getSnapshot, getTimestamp } = useSnapshots(
-    () => {},
-    isSuccess
-      ? data.tabs.reduce((acc, tab) => ({ ...acc, ...tab.snapshot }), {})
-      : {}
-  );
-
-  // Update the thumbnail either when the selection changes or when new data come in (potentially a new snapshot)
-  React.useEffect(() => {
-    let snapshot;
-    if (!screenSelection) {
-      snapshot = _getMostRecentSnapshot(tabSelection && tabSelection.value);
-    } else {
-      snapshot = getSnapshot({
-        // if there's not a current tab selection, then just grab the first (and only) tab id.
-        currentTabId: tabSelection
-          ? tabSelection.value
-          : getKeys()[0].currentTabId,
-        currentScreen: screenSelection && screenSelection.value,
-      });
-    }
-
-    setThumbnail(snapshot);
-  }, [tabSelection, screenSelection, data]);
-
-  /**
-   *
-   * HELPER FUNCTIONS
-   *
-   */
-
-  const _getMostRecentSnapshot = (tabId) => {
-    let relevantKeys = getKeys(); // if no tabId, return the most recent of all the room's snapshots
-    if (tabId) {
-      relevantKeys = relevantKeys.filter((key) => key.currentTabId === tabId);
-    }
-    let maxSoFar = 0;
-    let result = null;
-    relevantKeys.forEach((key) => {
-      if (getTimestamp(key) > maxSoFar) {
-        maxSoFar = getTimestamp(key);
-        result = getSnapshot(key);
-      }
-    });
-    return result;
-  };
-
-  // returns an array of the screen numbers for which we have snapshots on this tab.
-  const _getScreens = (tabId) => {
-    const tabKeys = getKeys().filter((key) => key.currentTabId === tabId);
-    return tabKeys.map((key) => key.currentScreen);
-  };
-
-  /**
-   *
-   * FUNCTION USED TO SIMPLIFY THE RENDER LOGIC. Creates the Select components, if needed, for tabs and screens.
-   *
-   */
-  const _tabsAndScreens = () => {
-    const tabOptions = data.tabs.map((tab) => {
-      return { value: tab._id, label: tab.name };
-    });
-
-    let screens = [];
-    if (tabOptions.length === 1) {
-      screens = _getScreens(tabOptions[0].value);
-    } else if (tabSelection) {
-      screens = _getScreens(tabSelection.value);
-    }
-
-    const screenOptions = screens.sort().map((screen) => {
-      return { value: screen, label: `Screen ${screen + 1}` };
-    });
-
-    return (
-      <Fragment>
-        {tabOptions.length > 1 && (
-          <Select
-            className={classes.Select}
-            options={tabOptions}
-            value={tabSelection}
-            onChange={(selectedOption) => setTabSelection(selectedOption)}
-            placeholder="Select a Tab..."
-          />
-        )}
-        {screenOptions.length > 1 && (
-          <Select
-            className={classes.Select}
-            options={screenOptions}
-            value={screenSelection}
-            onChange={(selectedOption) => setScreenSelection(selectedOption)}
-            placeholder="Select a Screen..."
-          />
-        )}
-        {!(tabOptions.length > 1) && !(screenOptions.length > 1) && 'Thumbnail'}
-      </Fragment>
-    );
-  };
-
   return (
     <div className={classes.Container}>
       <div className={classes.TileGroup}>
         <div className={classes.Tile}>
-          <div className={classes.TileContainer}>
-            <div
-              className={classes.Title}
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'flex-start',
-                alignItems: 'center',
-                marginBottom: '5px',
-              }}
-            >
-              {isSuccess ? _tabsAndScreens() : 'Loading...'}
-            </div>
-            {thumbnail ? (
-              <img alt="Snapshot of room" src={thumbnail} />
-            ) : (
-              <span className={classes.NoSnapshot}>No snapshot currently</span>
-            )}
-          </div>
+          {
+            <Thumbnails
+              populatedRoom={isSuccess ? data : {}}
+              defaultLabel="Thumbnail"
+            />
+          }
         </div>
         <div className={classes.Tile}>
           <div className={classes.TileContainer}>

--- a/client/src/Containers/Monitoring/Thumbnails.js
+++ b/client/src/Containers/Monitoring/Thumbnails.js
@@ -42,6 +42,11 @@ export default function Thumbnails({ populatedRoom, defaultLabel }) {
     setThumbnail(snapshot);
   }, [tabSelection, screenSelection, populatedRoom]);
 
+  // reset the screen selection when a tab is selected
+  React.useEffect(() => {
+    setScreenSelection(0);
+  }, [tabSelection]);
+
   /**
    *
    * HELPER FUNCTIONS

--- a/client/src/Containers/Monitoring/Thumbnails.js
+++ b/client/src/Containers/Monitoring/Thumbnails.js
@@ -1,0 +1,151 @@
+/* eslint-disable prettier/prettier */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+import { useSnapshots } from 'utils/utilityHooks';
+import classes from './monitoringView.css';
+
+export default function Thumbnails({ populatedRoom, defaultLabel }) {
+  const [tabSelection, setTabSelection] = React.useState();
+  const [screenSelection, setScreenSelection] = React.useState();
+  const [thumbnail, setThumbnail] = React.useState();
+
+  // Functions for accessing information in the snapshot object.
+  // getKeys() returns an array of all the keys being used for snapshots
+  // getSnapshot(key) returns the snapshot (dataURL) at that key
+  // getTimestamp(key) returns the timestamp (Unix epoch time) at that key
+  const { getKeys, getSnapshot, getTimestamp } = useSnapshots(
+    () => {},
+    populatedRoom.tabs
+      ? populatedRoom.tabs.reduce(
+          (acc, tab) => ({ ...acc, ...tab.snapshot }),
+          {}
+        )
+      : {}
+  );
+
+  // Update the thumbnail either when the selection changes or when new data come in (potentially a new snapshot)
+  React.useEffect(() => {
+    let snapshot;
+    if (!screenSelection) {
+      snapshot = _getMostRecentSnapshot(tabSelection && tabSelection.value);
+    } else {
+      snapshot = getSnapshot({
+        // if there's not a current tab selection, then just grab the first (and only) tab id.
+        currentTabId: tabSelection
+          ? tabSelection.value
+          : getKeys()[0].currentTabId,
+        currentScreen: screenSelection && screenSelection.value,
+      });
+    }
+
+    setThumbnail(snapshot);
+  }, [tabSelection, screenSelection, populatedRoom]);
+
+  /**
+   *
+   * HELPER FUNCTIONS
+   *
+   */
+
+  const _getMostRecentSnapshot = (tabId) => {
+    let relevantKeys = getKeys(); // if no tabId, return the most recent of all the room's snapshots
+    if (tabId) {
+      relevantKeys = relevantKeys.filter((key) => key.currentTabId === tabId);
+    }
+    let maxSoFar = 0;
+    let result = null;
+    relevantKeys.forEach((key) => {
+      if (getTimestamp(key) > maxSoFar) {
+        maxSoFar = getTimestamp(key);
+        result = getSnapshot(key);
+      }
+    });
+    return result;
+  };
+
+  // returns an array of the screen numbers for which we have snapshots on this tab.
+  const _getScreens = (tabId) => {
+    const tabKeys = getKeys().filter((key) => key.currentTabId === tabId);
+    return tabKeys.map((key) => key.currentScreen);
+  };
+
+  /**
+   *
+   * FUNCTION USED TO SIMPLIFY THE RENDER LOGIC. Creates the Select components, if needed, for tabs and screens.
+   *
+   */
+  const _tabsAndScreens = () => {
+    const tabs = populatedRoom.tabs || [];
+    const tabOptions = tabs.map((tab) => {
+      return { value: tab._id, label: tab.name };
+    });
+
+    let screens = [];
+    if (tabOptions.length === 1) {
+      screens = _getScreens(tabOptions[0].value);
+    } else if (tabSelection) {
+      screens = _getScreens(tabSelection.value);
+    }
+
+    const screenOptions = screens.sort().map((screen) => {
+      return { value: screen, label: `Screen ${screen + 1}` };
+    });
+
+    // Display something only if there's a tab selection, screen selection, or default label
+    return tabOptions.length > 1 || screenOptions.length > 1 || defaultLabel ? (
+      <div
+        className={classes.Title}
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+          marginBottom: '5px',
+        }}
+      >
+        {tabOptions.length > 1 && (
+          <Select
+            className={classes.Select}
+            options={tabOptions}
+            value={tabSelection}
+            onChange={(selectedOption) => setTabSelection(selectedOption)}
+            placeholder="Select a Tab..."
+          />
+        )}
+        {screenOptions.length > 1 && (
+          <Select
+            className={classes.Select}
+            options={screenOptions}
+            value={screenSelection}
+            onChange={(selectedOption) => setScreenSelection(selectedOption)}
+            placeholder="Select a Screen..."
+          />
+        )}
+        {!(tabOptions.length > 1) &&
+          !(screenOptions.length > 1) &&
+          defaultLabel}
+      </div>
+    ) : null;
+  };
+
+  return (
+    <div className={classes.TileContainer}>
+      {_tabsAndScreens()}
+      {thumbnail ? (
+        <img alt="Thumbnail of room" src={thumbnail} />
+      ) : (
+        <span className={classes.NoSnapshot}>No thumbnail currently</span>
+      )}
+    </div>
+  );
+}
+
+Thumbnails.propTypes = {
+  populatedRoom: PropTypes.shape({}).isRequired,
+  defaultLabel: PropTypes.string,
+};
+
+Thumbnails.defaultProps = {
+  defaultLabel: '',
+};


### PR DESCRIPTION
- Created a Thumbnails component that encapsulates the selection of alternative thumbnails for a room
- Refactored (greatly simplifying) RoomPreview and MonitoringView to use the new component
- fixed a bug whereby sometimes thumbnails wouldn't show for non-screen tabs
- changed 'snapshot' to 'thumbnail' in UI so that user gets consistent messaging